### PR TITLE
Fixed documentation regarding plug-in groupId

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Usage
 
 ```xml
 <plugin>
-    <groupId>com.any.joelittlejohn.embedmongo</groupId>
+    <groupId>com.github.joelittlejohn.embedmongo</groupId>
     <artifactId>embedmongo-maven-plugin</artifactId>
     <version>0.1.1</version>
     <executions>


### PR DESCRIPTION
Should be _github_ where _any_ was present in the usage instructions.
