### PR TITLE
Issue 13: graceful Network.localhostIsIPv6() call

### DIFF
--- a/src/main/java/com/github/joelittlejohn/embedmongo/StartEmbeddedMongoMojo.java
+++ b/src/main/java/com/github/joelittlejohn/embedmongo/StartEmbeddedMongoMojo.java
@@ -156,10 +156,8 @@ public class StartEmbeddedMongoMojo extends AbstractMojo {
             RuntimeConfig config = new RuntimeConfig();
             config.setProcessOutput(getOutputConfig());
 
-            executable = MongodStarter.getInstance(config).prepare(new MongodConfig(getVersion(), bindIp, port, Network.localhostIsIPv6(), getDataDirectory(), null, 0));
-        } catch (UnknownHostException e) {
-            throw new MojoExecutionException("Unable to determine if localhost is ipv6", e);
-        } catch (DistributionException e) {
+            executable = MongodStarter.getInstance(config).prepare(new MongodConfig(getVersion(), bindIp, port, isLocalhostIPV6(), getDataDirectory(), null, 0));
+        }  catch (DistributionException e) {
             throw new MojoExecutionException("Failed to download MongoDB distribution: " + e.withDistribution(), e);
         }
 
@@ -251,4 +249,14 @@ public class StartEmbeddedMongoMojo extends AbstractMojo {
         }
     }
 
+    private boolean isLocalhostIPV6() {
+        boolean isIp6;
+        try {
+            isIp6 = Network.localhostIsIPv6();
+        } catch (UnknownHostException e) {
+            getLog().warn("Unable to determine if localhost is IPv6, defaulting to false", e);
+            isIp6 = false;
+        }
+        return isIp6;
+    }
 }

--- a/src/test/resources/example/pom.xml
+++ b/src/test/resources/example/pom.xml
@@ -23,7 +23,7 @@
             <plugin>
                 <groupId>com.github.joelittlejohn.embedmongo</groupId>
                 <artifactId>embedmongo-maven-plugin</artifactId>
-                <version>0.1.5-SNAPSHOT</version>
+                <version>0.1.7-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <id>start</id>


### PR DESCRIPTION
Added a gracefully failing call to Network.localhostIsIPv6() in
StartEmbeddedMongoMojo.

Also, updated src/test/resources/example/pom.xml to have a project.version
that's the same as in the main pom.
