### PR TITLE
Made log file & encoding configurable

### DIFF
--- a/src/main/java/com/github/joelittlejohn/embedmongo/StartEmbeddedMongoMojo.java
+++ b/src/main/java/com/github/joelittlejohn/embedmongo/StartEmbeddedMongoMojo.java
@@ -134,6 +134,18 @@ public class StartEmbeddedMongoMojo extends AbstractMojo {
     private String logging;
 
     /**
+     * @parameter expression="${embedmongo.logFile}"
+     * @since 0.1.7
+     */
+    private String logFile = Loggers.DEFAULT_LOG_FILE_NAME;
+
+    /**
+     * @parameter expression="${embedmongo.logFileEncoding}"
+     * @since 0.1.7
+     */
+    private String logFileEncoding = Loggers.DEFAULT_LOG_FILE_ENCODING;
+
+    /**
      * The proxy user to be used when downloading MongoDB
      * 
      * @parameter expression="${embedmongo.proxyUser}"
@@ -204,7 +216,7 @@ public class StartEmbeddedMongoMojo extends AbstractMojo {
             case CONSOLE:
                 return Loggers.console();
             case FILE:
-                return Loggers.file();
+                return Loggers.file(logFile, logFileEncoding);
             case NONE:
                 return Loggers.none();
             default:

--- a/src/main/java/com/github/joelittlejohn/embedmongo/log/FileOutputStreamProcessor.java
+++ b/src/main/java/com/github/joelittlejohn/embedmongo/log/FileOutputStreamProcessor.java
@@ -24,13 +24,26 @@ import de.flapdoodle.embed.process.io.IStreamProcessor;
 public class FileOutputStreamProcessor implements IStreamProcessor {
 
     private static OutputStreamWriter stream;
+    
+    private String logFile;
+    private String encoding;
+    
+    public FileOutputStreamProcessor(String logFile) {
+        this(logFile, Loggers.DEFAULT_LOG_FILE_ENCODING);
+    }
 
+
+    public FileOutputStreamProcessor(String logFile, String encoding) {
+        setLogFile(logFile);
+        setEncoding(encoding);
+    }
+    
     @Override
     public synchronized void process(String block) {
         try {
 
             if (stream == null) {
-                stream = new OutputStreamWriter(new FileOutputStream("embedmongo.log"), "utf-8");
+                stream = new OutputStreamWriter(new FileOutputStream(logFile), encoding);
             }
 
             stream.write(block);
@@ -44,5 +57,19 @@ public class FileOutputStreamProcessor implements IStreamProcessor {
     @Override
     public void onProcessed() {
         process("\n");
+    }
+    
+    public void setLogFile(String logFile) {
+        if (logFile == null || logFile.trim().length() == 0) {
+            throw new IllegalArgumentException("no logFile given");
+        }
+        this.logFile = logFile;
+    }
+    
+    public void setEncoding(String encoding) {
+        if (encoding == null || encoding.trim().length() == 0) {
+            throw new IllegalArgumentException("no encoding given");
+        }
+        this.encoding = encoding;
     }
 }

--- a/src/main/java/com/github/joelittlejohn/embedmongo/log/Loggers.java
+++ b/src/main/java/com/github/joelittlejohn/embedmongo/log/Loggers.java
@@ -25,8 +25,11 @@ public class Loggers {
         FILE, CONSOLE, NONE
     }
 
-    public static ProcessOutput file() {
-        FileOutputStreamProcessor file = new FileOutputStreamProcessor();
+    public static final String DEFAULT_LOG_FILE_NAME = "embedmongo.log";
+    public static final String DEFAULT_LOG_FILE_ENCODING = "utf-8";
+
+    public static ProcessOutput file(String logFile, String encoding) {
+        FileOutputStreamProcessor file = new FileOutputStreamProcessor(logFile, encoding);
 
         return new ProcessOutput(
                 new NamedOutputStreamProcessor("[mongod output]", file),


### PR DESCRIPTION
Default log file is $PWD/embedmongo.log, which is not in the target folder.  Default remains the same (although I argue it should be changed to ${project.build.directory}/embedmongo.log), but now the log file name & encoding are configurable via <logFile> and <logFileEncoding> configuration parameters.
