### PR TITLE
Set the default logging to console (as it was previously)

### DIFF
--- a/src/main/java/com/github/joelittlejohn/embedmongo/StartMojo.java
+++ b/src/main/java/com/github/joelittlejohn/embedmongo/StartMojo.java
@@ -104,7 +104,7 @@ public class StartMojo extends AbstractEmbeddedMongoMojo {
     /**
      * @since 0.1.3
      */
-    @Parameter(property = "embedmongo.logging")
+    @Parameter(property = "embedmongo.logging", defaultValue = "console")
     private String logging;
 
     /**

--- a/src/test/resources/pom.xml
+++ b/src/test/resources/pom.xml
@@ -24,7 +24,7 @@
                 <plugin>
                     <groupId>com.github.joelittlejohn.embedmongo</groupId>
                     <artifactId>embedmongo-maven-plugin</artifactId>
-                    <version>0.1.13-SNAPSHOT</version>
+                    <version>0.1.14-SNAPSHOT</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Correct the default logging as console, at it was before the introduction of mongo-import and mongo-scripts