### PR TITLE
Skip does not work since it does not apply to the stop goal #55

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tagNameFormat>@{project.version}</tagNameFormat>
+        <maven.version>3.3.3</maven.version>
     </properties>
 
     <build>
@@ -123,23 +124,23 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>2.0</version>
+            <version>${maven.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-settings</artifactId>
-            <version>2.0</version>
+            <version>${maven.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.2</version>
+            <version>3.4</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-project</artifactId>
-            <version>2.0</version>
+            <version>2.2.1</version>
         </dependency>
         <dependency>
             <groupId>de.flapdoodle.embed</groupId>
@@ -164,6 +165,70 @@
             <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven.plugin-testing</groupId>
+            <artifactId>maven-plugin-testing-harness</artifactId>
+            <version>3.3.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>${maven.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-aether-provider</artifactId>
+            <version>${maven.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+            <version>${maven.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-compat</artifactId>
+            <version>${maven.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>3.0.15</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>${maven.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-container-default</artifactId>
+            <version>1.6</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact-manager</artifactId>
+            <version>2.2.1</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <profiles>

--- a/src/main/java/com/github/joelittlejohn/embedmongo/StopMojo.java
+++ b/src/main/java/com/github/joelittlejohn/embedmongo/StopMojo.java
@@ -19,14 +19,14 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 
 import de.flapdoodle.embed.mongo.MongodProcess;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
 
 /**
  * When invoked, this goal stops an instance of mojo that was started by this
  * plugin.
- *
- * @goal stop
- * @phase post-integration-test
  */
+@Mojo(name="stop", defaultPhase = LifecyclePhase.POST_INTEGRATION_TEST)
 public class StopMojo extends AbstractEmbeddedMongoMojo {
 
     @Override

--- a/src/test/java/com/github/joelittlejohn/embedmongo/SkipMojoTest.java
+++ b/src/test/java/com/github/joelittlejohn/embedmongo/SkipMojoTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright © 2012 Joe Littlejohn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.joelittlejohn.embedmongo;
+
+import org.apache.maven.plugin.testing.MojoRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SkipMojoTest {
+
+    @Rule
+    public MojoRule rule = new MojoRule();
+
+    private List<String> GOAL_LIST = Arrays.asList("start", "mongo-scripts", "mongo-import", "stop");
+
+    @Test
+    public void testSkipEnabled() throws Exception {
+        File pom = new File("src/test/resources/skipmojo/skipEnabled.xml");
+
+        for (String goal : GOAL_LIST) {
+            AbstractEmbeddedMongoMojo mojo = (AbstractEmbeddedMongoMojo) rule.lookupMojo(goal, pom);
+            assertTrue(mojo.isSkip());
+        }
+    }
+
+    @Test
+    public void testSkipDisabled() throws Exception {
+        File pom = new File("src/test/resources/skipmojo/skipDisabled.xml");
+
+        for (String goal : GOAL_LIST) {
+            AbstractEmbeddedMongoMojo mojo = (AbstractEmbeddedMongoMojo) rule.lookupMojo(goal, pom);
+            assertFalse(mojo.isSkip());
+        }
+    }
+}

--- a/src/test/resources/skipmojo/skipDisabled.xml
+++ b/src/test/resources/skipmojo/skipDisabled.xml
@@ -1,0 +1,47 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.joelittlejohn.embedmongo</groupId>
+    <artifactId>embedmongo-maven-plugin-test4</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.joelittlejohn.embedmongo</groupId>
+                <artifactId>embedmongo-maven-plugin</artifactId>
+                <configuration>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>start</id>
+                        <goals>
+                            <goal>start</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>mongo-scripts</id>
+                        <goals>
+                            <goal>mongo-scripts</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>mongo-import</id>
+                        <goals>
+                            <goal>mongo-import</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>stop</id>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/test/resources/skipmojo/skipEnabled.xml
+++ b/src/test/resources/skipmojo/skipEnabled.xml
@@ -1,0 +1,48 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.joelittlejohn.embedmongo</groupId>
+    <artifactId>embedmongo-maven-plugin-test4</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.joelittlejohn.embedmongo</groupId>
+                <artifactId>embedmongo-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>start</id>
+                        <goals>
+                            <goal>start</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>mongo-scripts</id>
+                        <goals>
+                            <goal>mongo-scripts</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>mongo-import</id>
+                        <goals>
+                            <goal>mongo-import</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>stop</id>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
It seems that the issue was caused by the fact that StopMojo was using the old way of defining the mojo goal using javadoc. After I changed to annotations it just worked.
I also wanted to write some tests to check this and I finally got the [Maven Plugin Testing Harness](https://maven.apache.org/plugin-testing/maven-plugin-testing-harness/) to work (very nasty, doc is really outdated), that is why some of the Maven artifact versions were bumped up (a lot of conflicts and missing classes). The only problem is that the tests seem to pass even with the old StopMojo. I would suggest to keep the test setup for the future.

Thanks