### PR TITLE
Master

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ Usage
         <scriptsDirectory>...</scriptsDirectory>
         <!-- a directory containing scripts to run -->
         
+        <scriptCharsetEncoding>UTF-8</scriptCharsetEncoding>
+        <!-- optional, valid charset encoding for loading the scripts. Uses the underlying charset encoding of the platform if not assigned -->
+        
         <databaseName>mydb</databaseName>
         <!-- the name of the database to run scripts against -->
         
@@ -132,3 +135,4 @@ Notes
 * If you need to use a proxy to download MongoDB then you can either use `-Dhttp.proxyHost` and `-Dhttp.proxyPort` as additional Maven arguments (this will affect the entire build) or [add proxy settings to your settings.xml](https://maven.apache.org/settings.html#Proxies).
 * If you're having trouble with Windows firewall rules, try setting the _bindIp_ config property to `127.0.0.1`.
 * If you'd like the start goal to start mongodb and wait, you can add `-Dembedmongo.wait` to your Maven command line arguments or `-Dembedmongo.import.wait` if you want the imports
+* If you are using a charset encoding to load scripts, refer to the [IANA Charset Registry](http://www.iana.org/assignments/character-sets/character-sets.xhtml).  Accepted charsets are found in the __Preferred MIME Name__ column.

--- a/src/test/java/com/github/joelittlejohn/embedmongo/MongoScriptsMojoTest.java
+++ b/src/test/java/com/github/joelittlejohn/embedmongo/MongoScriptsMojoTest.java
@@ -24,8 +24,11 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.net.UnknownHostException;
+
+import com.mongodb.DBCollection;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -54,7 +57,7 @@ public class MongoScriptsMojoTest {
     should_execute_instructions() throws MojoFailureException, MojoExecutionException, IOException {
         initFolder();
         try {
-            new MongoScriptsMojoForTest(rootFolder, PORT, "myDB").execute();
+            new MongoScriptsMojoForTest(rootFolder, PORT, "myDB", null).execute();
         } catch (Exception e) {
             e.printStackTrace();
             fail("Should not fail!");
@@ -68,7 +71,7 @@ public class MongoScriptsMojoTest {
         thrown.expect(MojoExecutionException.class);
         thrown.expectMessage("Database name is missing");
 
-        new MongoScriptsMojo(rootFolder, PORT, null).execute();
+        new MongoScriptsMojo(rootFolder, PORT, null, null).execute();
     }
 
     @Test public void
@@ -82,7 +85,18 @@ public class MongoScriptsMojoTest {
         thrown.expect(MojoExecutionException.class);
         thrown.expectMessage("Error while executing instructions from file '" + rootFolderWithError.listFiles()[0].getName());
 
-        new MongoScriptsMojoForTest(rootFolderWithError, PORT, "myDB", database).execute();
+        new MongoScriptsMojoForTest(rootFolderWithError, PORT, "myDB", database, null).execute();
+    }
+
+    @Test public void
+    should_not_accept_invalid_charset_encoding() throws IOException, MojoFailureException, MojoExecutionException {
+        initFolder();
+
+        String invalidScriptCharsetEncoding = "INVALID";
+        thrown.expect(MojoExecutionException.class);
+        thrown.expectMessage("Unable to determine charset encoding for provided charset '" + invalidScriptCharsetEncoding + "'");
+
+        new MongoScriptsMojoForTest(rootFolder, PORT, "myDB", invalidScriptCharsetEncoding).execute();
     }
 
     private void initFolder() throws IOException {
@@ -120,12 +134,12 @@ public class MongoScriptsMojoTest {
 
         private final DB database;
 
-        public MongoScriptsMojoForTest(File dataFolder, int port, String databaseName) throws UnknownHostException {
-            this(dataFolder, port, databaseName, new EmbedMongoDB("myDB"));
+        public MongoScriptsMojoForTest(File dataFolder, int port, String databaseName, String scriptCharsetEncoding) throws UnknownHostException {
+            this(dataFolder, port, databaseName, new EmbedMongoDB("myDB"), scriptCharsetEncoding);
         }
 
-        public MongoScriptsMojoForTest(File dataFolder, int port, String databaseName, DB database) {
-            super(dataFolder, port, databaseName);
+        public MongoScriptsMojoForTest(File dataFolder, int port, String databaseName, DB database, String scriptCharsetEncoding) {
+            super(dataFolder, port, databaseName, scriptCharsetEncoding);
             this.database = database;
         }
 


### PR DESCRIPTION
Added plugin param "scriptCharsetEncoding" to allow the script files to be read in using encoding other than that of the underlying platform.  Relying on the underlying platform encoding has caused issues running the scripts when the scripts contain UTF-8 characters in the JSON.
Updated documentation for the new param as well.