### PR TITLE
Support the configuration of the storageEngine and use latest de.flap…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
         <dependency>
             <groupId>de.flapdoodle.embed</groupId>
             <artifactId>de.flapdoodle.embed.mongo</artifactId>
-            <version>1.46.0</version>
+            <version>1.50.2</version>
         </dependency>
         <dependency>
             <groupId>org.mongodb</groupId>

--- a/src/main/java/com/github/joelittlejohn/embedmongo/StartMojo.java
+++ b/src/main/java/com/github/joelittlejohn/embedmongo/StartMojo.java
@@ -126,6 +126,14 @@ public class StartMojo extends AbstractEmbeddedMongoMojo {
 
     @Parameter(property = "embedmongo.journal", defaultValue = "false")
     private boolean journal;
+    
+    /**
+     * The storageEngine which shall be used
+     * 
+     * @since 0.3.4
+     */
+    @Parameter(property = "embedmongo.storageEngine", defaultValue = "wiredTiger")
+    private String storageEngine;
 
     @Component
     protected Settings settings;
@@ -175,6 +183,7 @@ public class StartMojo extends AbstractEmbeddedMongoMojo {
                     .replication(new Storage(getDataDirectory(), null, 0))
                     .cmdOptions(new MongoCmdOptionsBuilder()
                     		.useNoJournal(!journal)
+                    		.useStorageEngine(storageEngine)
                     		.build())
                     .build();
 


### PR DESCRIPTION
With MongoDB 3.2.x the default storageEngine became wiredTiger. In some cases it's not requested to let the "Embeded"-MongoDB use this storageEngine but test e.g. with the In-Memory Database.
This change supports the configuration of the storageEngine.