### PR TITLE
Include the option ‘storageEngine’ in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Usage
         <skip>false</skip>
         <!-- optional, skips this plugin entirely, use on the command line like -Dembedmongo.skip -->
         
+        <storageEngine>mmapv1</storageEngine>
+        <!-- optional, default is wiredTiger. See https://docs.mongodb.org/manual/core/storage-engines/ for details. -->
+        
       </configuration>
     </execution>
     <execution>


### PR DESCRIPTION
This will include the `storageEngine` option in the README.md as it was requested in  https://github.com/joelittlejohn/embedmongo-maven-plugin/pull/60

No yet changed is the definition of the default `storageEngine`. Has to be defined ;-)