### PR TITLE
Option to fail build when scripts directory is missing

### DIFF
--- a/src/main/java/com/github/joelittlejohn/embedmongo/MongoScriptsMojo.java
+++ b/src/main/java/com/github/joelittlejohn/embedmongo/MongoScriptsMojo.java
@@ -63,14 +63,24 @@ public class MongoScriptsMojo extends AbstractEmbeddedMongoMojo {
     @Parameter(property = "databaseName", required = true)
     private String databaseName;
 
+    /**
+     * Determines whether build should fail when scrip directory is missing
+     */
+    @Parameter(property = "failOnMissingDirectory", required = true)
+    private boolean failOnMissingDirectory;
+
+
     public MongoScriptsMojo() {
     }
 
-    MongoScriptsMojo(File scriptsDirectory, int port, String databaseName, String scriptCharsetEncoding) {
+    MongoScriptsMojo(File scriptsDirectory, int port, String databaseName,
+                     String scriptCharsetEncoding, boolean failOnMissingDirectory) {
+
         super(port);
         this.scriptsDirectory = scriptsDirectory;
         this.databaseName = databaseName;
         this.scriptCharsetEncoding = scriptCharsetEncoding;
+        this.failOnMissingDirectory = failOnMissingDirectory;
     }
 
     @Override
@@ -127,6 +137,12 @@ public class MongoScriptsMojo extends AbstractEmbeddedMongoMojo {
                 }
             }
             getLog().info("Data initialized with success");
+        } else {
+            String message = "Script directory: " + scriptsDirectory + " doesn't exist";
+            getLog().warn(message);
+            if (failOnMissingDirectory) {
+                throw new MojoExecutionException(message);
+            }
         }
     }
 

--- a/src/test/java/com/github/joelittlejohn/embedmongo/MongoScriptsMojoTest.java
+++ b/src/test/java/com/github/joelittlejohn/embedmongo/MongoScriptsMojoTest.java
@@ -71,7 +71,7 @@ public class MongoScriptsMojoTest {
         thrown.expect(MojoExecutionException.class);
         thrown.expectMessage("Database name is missing");
 
-        new MongoScriptsMojo(rootFolder, PORT, null, null).execute();
+        new MongoScriptsMojo(rootFolder, PORT, null, null, false).execute();
     }
 
     @Test public void
@@ -97,6 +97,26 @@ public class MongoScriptsMojoTest {
         thrown.expectMessage("Unable to determine charset encoding for provided charset '" + invalidScriptCharsetEncoding + "'");
 
         new MongoScriptsMojoForTest(rootFolder, PORT, "myDB", invalidScriptCharsetEncoding).execute();
+    }
+
+    @Test public void
+    should_fail_on_missing_scripts_directory() throws MojoFailureException, MojoExecutionException {
+        boolean shouldFail = true;
+
+        File invalidDirectory = new File("./dummy/dir");
+        thrown.expect(MojoExecutionException.class);
+        thrown.expectMessage("Script directory: ./dummy/dir doesn't exist");
+
+        new MongoScriptsMojoForTest(invalidDirectory, PORT, "myDB", null, null, shouldFail).execute();
+    }
+
+    @Test public void
+    should_ignore_missing_scripts_directory() throws MojoFailureException, MojoExecutionException {
+        boolean shouldFail = false;
+
+        File invalidDirectory = new File("./dummy/dir");
+
+        new MongoScriptsMojoForTest(invalidDirectory, PORT, "myDB", null, null, shouldFail).execute();
     }
 
     private void initFolder() throws IOException {
@@ -139,7 +159,13 @@ public class MongoScriptsMojoTest {
         }
 
         public MongoScriptsMojoForTest(File dataFolder, int port, String databaseName, DB database, String scriptCharsetEncoding) {
-            super(dataFolder, port, databaseName, scriptCharsetEncoding);
+            super(dataFolder, port, databaseName, scriptCharsetEncoding, false);
+            this.database = database;
+        }
+
+        public MongoScriptsMojoForTest(File dataFolder, int port, String databaseName, DB database,
+                                       String scriptCharsetEncoding, boolean failOnMissingDirectory) {
+            super(dataFolder, port, databaseName, scriptCharsetEncoding, failOnMissingDirectory);
             this.database = database;
         }
 


### PR DESCRIPTION
Just a little useful option I thought about when I wondered why my tests were failing after I shuffled a couple of directories. 