### PR TITLE
Update embed mongodb version and fix commons-io version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,11 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.0.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
                 <version>3.4</version>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,14 @@
             <artifactId>maven-plugin-testing-harness</artifactId>
             <version>3.3.0</version>
             <scope>test</scope>
+            <exclusions>
+                <!-- for an unknown reason, without this commons-io 2.2 overrides the
+                commons-io 2.4 required by de.flapdoodle.embed.mongo -->
+                <exclusion>
+                    <groupId>commons-io</groupId>
+                    <artifactId>commons-io</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
         <dependency>
             <groupId>de.flapdoodle.embed</groupId>
             <artifactId>de.flapdoodle.embed.mongo</artifactId>
-            <version>1.50.2</version>
+            <version>1.50.5</version>
         </dependency>
         <dependency>
             <groupId>org.mongodb</groupId>


### PR DESCRIPTION
When I use the plugin in our own project, at the end I seem to get the error below. This PR takes some steps to try and resolve it, but unfortunately does not fix the issue. Does anyone have any ideas?

Seems related to - https://github.com/joelittlejohn/embedmongo-maven-plugin/issues/44 which is still unsolved.

```
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
Exception in thread "Thread-1" java.lang.NoClassDefFoundError: de/flapdoodle/embed/process/extract/ExtractedFileSets
	at de.flapdoodle.embed.process.store.ArtifactStore.removeFileSet(ArtifactStore.java:90)
	at de.flapdoodle.embed.process.store.CachingArtifactStore$FilesWithCounter.forceDelete(CachingArtifactStore.java:176)
	at de.flapdoodle.embed.process.store.CachingArtifactStore.removeAll(CachingArtifactStore.java:100)
	at de.flapdoodle.embed.process.store.CachingArtifactStore$CacheCleaner.run(CachingArtifactStore.java:196)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.ClassNotFoundException: de.flapdoodle.embed.process.extract.ExtractedFileSets
	at org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy.loadClass(SelfFirstStrategy.java:50)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.unsynchronizedLoadClass(ClassRealm.java:271)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:247)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:239)
	... 5 more
Fri May  4 12:38:51 [initandlisten] connection accepted from 127.0.0.1:54200 #14 (1 connection now open)
[mongod output] Fri May  4 12:38:51 [conn14] terminating, shutdown command received
[mongod output] Fri May  4 12:38:51 dbexit: shutdown called
[mongod output] Fri May  4 12:38:51 [conn14] shutdown: going to close listening sockets...
[mongod output] Fri May  4 12:38:51 [conn14] closing listening socket: 5
[mongod output] Fri May  4 12:38:51 [conn14] closing listening socket: 6
[mongod output] Fri May  4 12:38:51 [conn14] removing socket file: /tmp/mongodb-27017.sock
[mongod output] Fri May  4 12:38:51 [conn14] shutdown: going to flush diaglog...
[mongod output] Fri May  4 12:38:51 [conn14] shutdown: going to close sockets...
[mongod output] Fri May  4 12:38:51 [conn14] shutdown: waiting for fs preallocator...
[mongod output] Fri May  4 12:38:51 [conn14] shutdown: closing all files...
[mongod output] Fri May  4 12:38:51 [conn14] closeAllFiles() finished
[mongod output] Fri May  4 12:38:51 [conn14] shutdown: removing fs lock...
[mongod output] Fri May  4 12:38:51 dbexit: really exiting now
[mongod output] 
Exception in thread "Thread-3" java.lang.NoClassDefFoundError: org/apache/commons/io/FileUtils
	at de.flapdoodle.embed.process.io.file.Files.forceDelete(Files.java:119)
	at de.flapdoodle.embed.mongo.MongodProcess.deleteTempFiles(MongodProcess.java:92)
	at de.flapdoodle.embed.mongo.AbstractMongoProcess.cleanupInternal(AbstractMongoProcess.java:124)
	at de.flapdoodle.embed.process.runtime.AbstractProcess.stop(AbstractProcess.java:172)
	at de.flapdoodle.embed.process.runtime.AbstractProcess$JobKiller.run(AbstractProcess.java:243)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.ClassNotFoundException: org.apache.commons.io.FileUtils
	at org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy.loadClass(SelfFirstStrategy.java:50)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.unsynchronizedLoadClass(ClassRealm.java:271)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:247)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:239)
	... 6 more
```