### PR TITLE
ready 0.4.1 for release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.github.joelittlejohn.embedmongo</groupId>
     <artifactId>embedmongo-maven-plugin</artifactId>
-    <version>0.4.1-SNAPSHOT</version>
+    <version>0.4.1</version>
 
     <packaging>maven-plugin</packaging>
 


### PR DESCRIPTION
Ready to tag 0.4.1 for maven release that includes Flapdoodle embed mongo 2.1.1