### PR TITLE
Enable depedency caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,4 @@
 language: java
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION
Would be interested to know why maven dependencies haven't been cached on Travis. Thank you.