### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,12 +204,7 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.6</version>
-            <scope>test</scope>
-        </dependency>
+        
 
         <dependency>
             <groupId>org.apache.maven.plugin-testing</groupId>
@@ -226,33 +221,13 @@
             </exclusions>
         </dependency>
 
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-core</artifactId>
-            <version>${maven.version}</version>
-            <scope>test</scope>
-        </dependency>
+        
 
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-compat</artifactId>
-            <version>${maven.version}</version>
-            <scope>test</scope>
-        </dependency>
+        
 
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-artifact</artifactId>
-            <version>${maven.version}</version>
-            <scope>test</scope>
-        </dependency>
+        
 
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-artifact-manager</artifactId>
-            <version>2.2.1</version>
-            <scope>test</scope>
-        </dependency>
+        
 
     </dependencies>
 


### PR DESCRIPTION

[Apache Maven Dependency Plugin](https://maven.apache.org/plugins/maven-dependency-plugin/index.html) can be used to find unused dependencies. And I found following list. Maybe we can remove them.
embedmongo-maven-plugin
{groupId='commons-io', artifactId='commons-io'}
{groupId='org.apache.maven', artifactId='maven-core'}
{groupId='org.apache.maven', artifactId='maven-compat'}
{groupId='org.apache.maven', artifactId='maven-artifact'}
{groupId='org.apache.maven', artifactId='maven-artifact-manager'}


=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
